### PR TITLE
Fixing BufferedImage exception at initialization on headless machines

### DIFF
--- a/src/main/java/com/extremelyd1/main/Bingo.java
+++ b/src/main/java/com/extremelyd1/main/Bingo.java
@@ -8,6 +8,7 @@ public class Bingo extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        System.setProperty("java.awt.headless", "true");
         getLogger().info("Creating Game instance");
         try {
             new Game(this);


### PR DESCRIPTION
This avoids `java.awt.GraphicsEnvironment` throwing an exception during its construction (itself occurring during `BufferedImage` construction) on machines that don't have a screen.