### PR TITLE
Fix config `border.enable` does not affect the nether

### DIFF
--- a/src/main/java/com/extremelyd1/world/WorldManager.java
+++ b/src/main/java/com/extremelyd1/world/WorldManager.java
@@ -107,9 +107,11 @@ public class WorldManager implements Listener {
             world.setAutoSave(false);
             world.setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, false);
 
-            Game.getLogger().info("Setting nether world border...");
-            setWorldBorder(nether);
-            Game.getLogger().info("Nether border set");
+            if (game.getConfig().isBorderEnabled()) {
+                Game.getLogger().info("Setting nether world border...");
+                setWorldBorder(nether);
+                Game.getLogger().info("Nether border set");
+            }
         } else if (world.getEnvironment().equals(World.Environment.THE_END) && this.end == null) {
             this.end = world;
 


### PR DESCRIPTION
The issue is introduced from the refactor in commit 725dd88d01607c7bb53bcca6d07ec2c8bd76bcf3

Previous behavior (18ec67dd64c01666cd6b178b4b357df4dd980c08), where the config `border.enable` is able to switch on/off the border of the nether:

https://github.com/Extremelyd1/minecraft-bingo/blob/18ec67dd64c01666cd6b178b4b357df4dd980c08/src/main/java/com/extremelyd1/world/WorldManager.java#L94-L111

Current behavior (725dd88d01607c7bb53bcca6d07ec2c8bd76bcf3), where the border of the nether is always enabled no matter what `border.enable` is:

https://github.com/Extremelyd1/minecraft-bingo/blob/725dd88d01607c7bb53bcca6d07ec2c8bd76bcf3/src/main/java/com/extremelyd1/world/WorldManager.java#L104-L113
