### PR TITLE
Add ability to define a start kit in config

### DIFF
--- a/src/main/java/com/extremelyd1/config/Config.java
+++ b/src/main/java/com/extremelyd1/config/Config.java
@@ -1,8 +1,13 @@
 package com.extremelyd1.config;
 
 import com.extremelyd1.game.progress.ProgressController;
+import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.List;
+import java.util.Objects;
 
 public class Config {
 
@@ -109,6 +114,15 @@ public class Config {
      */
     private final int preGameBorderRadius;
 
+    /**
+     * Whether the start kit is enabled
+     */
+    private final boolean startKitEnabled;
+    /**
+     * The items given in the start kit
+     */
+    private final List<ItemStack> startKitItems;
+
     public Config(JavaPlugin plugin) throws IllegalArgumentException {
         plugin.saveDefaultConfig();
         
@@ -165,6 +179,12 @@ public class Config {
         preGenerateWorlds = borderEnabled && config.getBoolean("pregeneration-mode.enable");
 
         preGameBorderRadius = config.getInt("pregame.border-radius");
+
+        startKitEnabled = config.getBoolean("start-kit.enable");
+        startKitItems = config.getStringList("start-kit.items").stream()
+                .map(this::parseItemStack)
+                .filter(Objects::nonNull)
+                .toList();
     }
 
     /**
@@ -178,6 +198,27 @@ public class Config {
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Default item distribution config value has a non-integer value");
         }
+    }
+
+    /**
+     * Parse the given string value to an item stack or throw an exception if not possible
+     * @param stringValue The string value to parse
+     * @return The parsed item stack
+     */
+    private ItemStack parseItemStack(String stringValue) {
+        String[] parts = stringValue.split(" ");
+        if (parts.length == 2) {
+            try {
+                Material material = Material.matchMaterial(parts[0]);
+                int amount = Integer.parseInt(parts[1]);
+                if (material != null) {
+                    return ItemStack.of(material, amount);
+                }
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Start kit items config contains an invalid item");
+            }
+        }
+        return null;
     }
 
     public ProgressController getProgressController() {
@@ -288,5 +329,13 @@ public class Config {
 
     public int getPreGameBorderRadius() {
         return preGameBorderRadius;
+    }
+
+    public boolean isStartKitEnabled() {
+        return startKitEnabled;
+    }
+
+    public List<ItemStack> getStartKitItems() {
+        return startKitItems;
     }
 }

--- a/src/main/java/com/extremelyd1/game/Game.java
+++ b/src/main/java/com/extremelyd1/game/Game.java
@@ -25,7 +25,10 @@ import io.papermc.paper.command.brigadier.BasicCommand;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Player;
@@ -330,6 +333,11 @@ public class Game {
                         bingoCard,
                         team
                 ));
+
+                // Give start kit if enabled
+                if (config.isStartKitEnabled()) {
+                    config.getStartKitItems().forEach(item -> teamPlayer.getInventory().addItem(item));
+                }
 
                 if (config.isGiveAllRecipes()) {
                     recipeUtil.discoverAllRecipes(teamPlayer);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,3 +31,7 @@ pregeneration-mode:
   enable: False
 pregame:
   border-radius: 20
+start-kit:
+  enable: False
+  items:
+    - minecraft:cooked_beef 20


### PR DESCRIPTION
As a regular user of the plugin, I use to give some food to all players at the start of the game.
So I thought, why not incorporate this into the plugin config directly?

This PR adds two new config options:
- start-kit.enable
- start-kit.items